### PR TITLE
See issue cited for master branch

### DIFF
--- a/counting-minutes.js
+++ b/counting-minutes.js
@@ -4,62 +4,80 @@ Have the function CountingMinutes(str) take the str parameter being passed which
 
 function CountingMinutes(str) { 
   
-  function ClockTime(ampm, hour, minute) {
-    if (ampm === 'am') { 
-      this.am = true;
-      this.pm = false;
-    } else {
-      this.am = false;
-      this.pm = true;
-    }
-    
-    this.hour = hour;
-    this.minute = minute;
-  }
+	function Clocktime(ampm, hour, minute) {  
+		if (ampm === "am") {
+		this.am = true;
+		this.pm = false;
+		} else {
+		this.pm = true;
+		this.am = false;
+		}
+		this.minute = minute;  
+		this.hour = hour;      
 
-  ClockTime.prototype.eventTime = function () {
-    if (this.am) {
-        return this.hour * 60 + this.minute;
-    } else {
-        return 12*60 + this.hour * 60 + this.minute;
-    }
-  };
-  
-  ClockTime.prototype.timeTillEOD = function () {
-    return 24 * 60 - this.eventTime();
-  };
+	Clocktime.prototype.timeFromBOD = function() {    //Clocktime object method (note the exception made for noon & midnight hours)
+		if (this.am) {
+		    if (this.hour === 12) {
+		        return this.minute;
+		    }
+		  else {return this.hour * 60 + this.minute;
+		 }
+		}
+		if (this.pm) {
+		  if (this.hour === 12) {
+                return this.hour * 60 + this.minute;
+			}
+		  else {return 12 * 60 + this.hour * 60 + this.minute;
+		 }
+	    }
+	}
 
-  var times = str.split('-');
-  var time1_ampm = times[0].substring(times[0].length - 2);
-  var time1_hour = parseInt(times[0].split(':')[0], 10);
-  var time1_min = parseInt(times[0].split(':')[1], 10);
+	Clocktime.prototype.timeTillEOD = function() {    //Clocktime object method (note the exception made for noon & midnight hours)
+		if (this.am) {
+		    if (this.hour === 12) {
+		        return 24 * 60 - (this.minute);
+		    }
+		  else {return 24 * 60 - (this.hour * 60 + this.minute);
+		  }
+		}
+		if (this.pm) {
+			if (this.hour === 12) {
+                return 24 * 60 - (this.hour * 60 + this.minute);
+			}
+		  else {return 12 * 60 - (this.hour * 60 + this.minute);
+		  }
+		}
+	}
 
-  var time2_ampm = times[1].substring(times[1].length - 2);
-  var time2_hour = parseInt(times[1].split(':')[0], 10);
-  var time2_min = parseInt(times[1].split(':')[1], 10);
+	var times = str.split("-");
+	var time1ampm = times[0].substring(times[0].length-2);
+	var time2ampm = times[1].substring(times[1].length-2);
+	var time1minute = parseInt(times[0].slice(0, times[0].length-2).split(":")[1], 10);  
+	var time2minute = parseInt(times[1].slice(0, times[1].length-2).split(":")[1], 10);
+	var time1hour = parseInt(times[0].slice(0, times[0].length-2).split(":")[0], 10);  //here, parseInt doesn't change the radix but does convert the string # to a number value
+	var time2hour = parseInt(times[1].slice(0, times[1].length-2).split(":")[0], 10);
+	var time1 = new Clocktime(time1ampm, time1hour, time1minute);      //object instances
+	var time2 = new Clocktime(time2ampm, time2hour, time2minute);
 
-  var time1 = new ClockTime(time1_ampm, time1_hour, time1_min);
-  var time2 = new ClockTime(time2_ampm, time2_hour, time2_min);
-  
-  if (time1.am && time2.pm) {
-    return time2.eventTime() - time1.eventTime();
-  } else if (time1.pm && time2.am) {
-    return time1.timeTillEOD() + time2.eventTime();
-  } else if (time1.am && time2.am) {
-    if (time1.eventTime() < time2.eventTime()) {
-      return time2.eventTime() - time1.eventTime();
-    } else {
-      return time1.timeTillEOD() + time2.eventTime();
-    }
-  } else if (time1.pm && time2.pm) {
-    if (time1.eventTime() < time2.eventTime()) {
-      return time2.eventTime() - time1.eventTime();
-    } else {
-      return time1.timeTillEOD() + time2.eventTime();
-    }
-  }
-  
-            
+	if (time1.am && time2.am) {
+		if (time1.timeFromBOD() < time2.timeFromBOD()) {
+			return time2.timeFromBOD() - time1.timeFromBOD();
+		} else {
+			return time1.timeTillEOD() + time2.timeFromBOD();
+		}
+	}
+	if (time1.am && time2.pm) {
+		return time2.timeFromBOD() - time1.timeFromBOD();
+	} else if (time1.pm && time2.am) {
+		return time1.timeTillEOD() + time2.timeFromBOD();
+	}
+	if (time1.pm && time2.pm) {
+		if (time1.timeFromBOD() < time2.timeFromBOD()) {
+			return time2.timeFromBOD() - time1.timeFromBOD();
+		} else {
+			return time1.timeTillEOD() + time2.timeFromBOD();
+		}
+	}
 }
    
 // this call is needed to test your function


### PR DESCRIPTION
The original code doesn't always work for 12:00-12:59am/pm. For example, if you use this code as is to find the number of minutes between "3:00pm-12:05am" you will get 1265 minutes for your answer because the program will think that it's counting from 3:00pm until 12:05**pm** the next day. The answer should be 545 minutes. Exceptions need to be made for the noon and midnight hours because these two hours uniquely spill over into the next am/pm cycle while still counting upward from the previous cycle. This is no longer an issue when 1:00(am or pm) is reached.

See my edits that make exceptions for the 12:00 hours to fix this problem.
